### PR TITLE
Fix typo in github pages as well

### DIFF
--- a/context.jsonld
+++ b/context.jsonld
@@ -1,7 +1,7 @@
 {
     "@context" : {
 		"@vocab" : "http://openlca.org/schema/v1.0/",
-		"@base": "http://openlca.org/schema/v1.0/"
+		"@base": "http://openlca.org/schema/v1.0/",
 		"modelType" : {
 			"@type" : "@vocab"
 		},


### PR DESCRIPTION
Schema refers to http://greendelta.github.io/olca-schema/context.jsonld, which hasn't been updated for typo
