### PR TITLE
Add Reference to `UnitGroup` in `Unit`

### DIFF
--- a/yaml/Unit.yaml
+++ b/yaml/Unit.yaml
@@ -25,3 +25,8 @@ class:
     - name: synonyms
       type: List[string]
       doc: A list of synonyms for the unit.
+    
+    - name: unitGroup
+      type: Ref[UnitGroup]
+      doc: The unit group to which the unit belongs.
+    


### PR DESCRIPTION
Add a new attribute to `Unit` model, a `Ref` pointing to the `UnitGroup` to which the `Unit` belongs.

## Why?

Having this reference improves the domain model, avoiding unnecessary boilerplate code in other applications to find out the `UnitGroup` of a specific `Unit`.

## Example

Right now, the CSV format of openLCA reference data for units has the following columns:

0. reference ID (UUID; required)
1. name (string; required)
2. description (string; optional)
3. conversion factor (double; required)
4. synonyms (string: list separated by semicolon; optional)
5. reference ID of unit group (UUID, required)

For example, a Repository to manage these files may be implemented in Python. Right now it could look like:

```python
class CsvRepository(AbstractRepository):
    def __init__(self, path: str) -> None:
        self.__path = path

    def add(self, entity: Unit) -> None:
        with open(self.__path, "a", encoding="utf-8") as file:
            writer = csv.writer(file)
            writer.writerow(
                [
                    entity.id,
                    entity.name,
                    entity.description,
                    entity.conversion_factor,
                    entity.synonyms,
                    function_to_find_the_unit_group_of(entitiy, unit_groups),
                ]
            )
```

The implementation would be easier just having `entity.unit_group.id`.

